### PR TITLE
[PR] Rust: Change To Using `probe rs` For Debugging

### DIFF
--- a/source/app/STM32L432KC_Rust/.vscode/launch.json
+++ b/source/app/STM32L432KC_Rust/.vscode/launch.json
@@ -1,31 +1,23 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Cortex Debug",
-            "cwd": "${workspaceFolder}",
-            "executable": "${workspaceFolder}/target/thumbv7em-none-eabi/debug/nucleo_l432kc_embassy",
+            "type": "probe-rs-debug",
             "request": "launch",
-            "type": "cortex-debug",
-            "runToEntryPoint": "main",
-            "servertype": "openocd",
-            "device": "STM32L432KC",
-            "configFiles": [
-                "interface/stlink.cfg",
-                "target/stm32l4x.cfg"
-            ],
-            "svdFile": "${workspaceFolder}/STM32L4x2.svd",
-            "preLaunchTask": "Build binary",
-            "preLaunchCommands": [
-                "monitor init",
-                "monitor reset init",
-                "monitor halt",
-                "monitor flash write_image erase ./target/thumbv7em-none-eabi/debug/nucleo_l432kc_embassy 0x08000000"
-            ],
-            "postLaunchCommands": ["monitor reset init"]
+            "name": "probe-rs Debug",
+            "chip": "STM32L432KCUx",
+            "flashingConfig": {
+                "flashingEnabled": true,
+                "resetAfterFlashing": true,
+                "haltAfterReset": true
+            },
+            "coreConfigs": [
+                {
+                    "coreIndex": 0,
+                    "rttEnabled": true,
+                    "programBinary": "./target/thumbv7em-none-eabi/debug/nucleo_l432kc_embassy"
+                }
+            ]
         }
-    ],
+    ]
 }

--- a/source/app/STM32L432KC_Rust/.vscode/settings.json
+++ b/source/app/STM32L432KC_Rust/.vscode/settings.json
@@ -6,6 +6,8 @@
     "search.exclude": {
         "**/*.bak": true,
         "**/*rs.bak": true,
+    },
+    "[rust]": {
+        "editor.formatOnSave": false
     }
 }
-

--- a/source/app/STM32L432KC_Rust/README.md
+++ b/source/app/STM32L432KC_Rust/README.md
@@ -31,10 +31,10 @@
 
 * Nucleo H/W Setup
   * Serial interface for CLI
-    * Module - USART2
+    * Module - USART2 (VCOM)
 	  * Pins (NucleoL432KC)
 		* TX: A7 (PA2)
-		* RX: A2 (PA3)
+		* RX: A2 (PA15)
 	* Baudrate : 115200
 	  * Line feed setting in Teraterm: TX: **CR+LF** and RX: **CR**
 	* When connecting a UART-to-USB module to the laptop, make sure the com port is not of Nucleo's.

--- a/source/app/STM32L432KC_Rust/src/main.rs
+++ b/source/app/STM32L432KC_Rust/src/main.rs
@@ -164,9 +164,9 @@ async fn main(spawner: Spawner) {
     // LED
     let led = Output::new(p.PB3, Level::High, Speed::Low);
 
-    // USART2
+    // USART2 (VCOM)
     let config = embassy_stm32::usart::Config::default();    
-    let serial = Uart::new(p.USART2, p.PA3, p.PA2, Irqs, p.DMA1_CH7, p.DMA1_CH6, config).unwrap();
+    let serial = Uart::new(p.USART2, p.PA15, p.PA2, Irqs, p.DMA1_CH7, p.DMA1_CH6, config).unwrap();
     let (serial_tx, serial_rx) = serial.split();
     cli::create_singleton_sender(serial_tx);
 


### PR DESCRIPTION
# Summary
1. Change to using `probe-rs` for debugging environment. It looks like there's been better interface officially supported in Rust.
2. Change to using VCOM on USART2.
3. Disable 'format on save'.